### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for custom-metrics-autoscaler-operator

### DIFF
--- a/Dockerfile.cma-operator
+++ b/Dockerfile.cma-operator
@@ -69,7 +69,8 @@ USER nobody
 LABEL io.k8s.display-name="OpenShift Custom Metrics Autoscaler Operator" \
       io.k8s.description="This is a component of OpenShift which manages Custom Metrics Autoscaler." \
       com.redhat.component="custom-metrics-autoscaler-operator-container" \
-      name="custom-metrics-autoscaler-operator-rhel-9" \
+      name="custom-metrics-autoscaler/custom-metrics-autoscaler-rhel9-operator" \
+      cpe="cpe:/a:redhat:openshift_custom_metrics_autoscaler:2.15::el9" \
       summary="custom-metrics-autoscaler-operator" \
       io.openshift.expose-services="" \
       io.openshift.tags="openshift,custom-metrics-autoscaler-operator" \


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
