### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for keda-operator

### DIFF
--- a/Dockerfile.keda-operator
+++ b/Dockerfile.keda-operator
@@ -61,8 +61,8 @@ USER nobody
 LABEL io.k8s.display-name="OpenShift Custom Metrics Autoscaler" \
       io.k8s.description="This is a component of OpenShift which provides pod scaling capabilities based upon various metrics sources." \
       com.redhat.component="custom-metrics-autoscaler-container" \
-      name="custom-metrics-autoscaler-rhel-9" \
-      summary="custom-metrics-autoscaler" \
+      name="custom-metrics-autoscaler/custom-metrics-autoscaler-rhel9" \
+      cpe="cpe:/a:redhat:openshift_custom_metrics_autoscaler:2.15::el9" \
       io.openshift.expose-services="" \
       io.openshift.tags="openshift,custom-metrics-autoscaler" \
       description="custom-metrics-autoscaler-container" \


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
