### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for keda-webhooks

### DIFF
--- a/Dockerfile.keda-webhooks
+++ b/Dockerfile.keda-webhooks
@@ -59,7 +59,8 @@ USER nobody
 LABEL io.k8s.display-name="OpenShift Custom Metrics Autoscaler Admission Webhooks" \
       io.k8s.description="This is a component of OpenShift which validates KEDA objects." \
       com.redhat.component="custom-metrics-autoscaler-admission-webhooks-container" \
-      name="custom-metrics-autoscaler-admission-webhooks-rhel-9" \
+      name="custom-metrics-autoscaler/custom-metrics-autoscaler-admission-webhooks-rhel9" \
+      cpe="cpe:/a:redhat:openshift_custom_metrics_autoscaler:2.15::el9" \
       summary="custom-metrics-autoscaler-admission-webhooks" \
       io.openshift.expose-services="" \
       io.openshift.tags="openshift,custom-metrics-autoscaler-admission-webhooks" \


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
