### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for keda-adapter

### DIFF
--- a/Dockerfile.keda-adapter
+++ b/Dockerfile.keda-adapter
@@ -60,7 +60,8 @@ USER nobody
 LABEL io.k8s.display-name="OpenShift Custom Metrics Autoscaler Adapter" \
       io.k8s.description="This is a component of OpenShift which provides a custom metrics API endpoint for pod autoscaling." \
       com.redhat.component="custom-metrics-autoscaler-adapter-container" \
-      name="custom-metrics-autoscaler-adapter-rhel-9" \
+      name="custom-metrics-autoscaler/custom-metrics-autoscaler-adapter-rhel9" \
+      cpe="cpe:/a:redhat:openshift_custom_metrics_autoscaler:2.15::el9" \
       summary="custom-metrics-autoscaler-adapter" \
       io.openshift.expose-services="" \
       io.openshift.tags="openshift,custom-metrics-autoscaler-adapter" \


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
